### PR TITLE
Proguard setup and gitignore setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ proguard/
 .navigation/
 
 # Android Studio captures folder
+.Ds_Store
 captures/
 
 # IntelliJ

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,10 @@ android {
     }
 
     buildTypes {
+        debug {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -14,8 +14,8 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable,InnerClasses,Exceptions,Signature
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-renamesourcefileattribute SourceFile


### PR DESCRIPTION
18a959190ba335ef08ca021b4d01f294351737ff‥delete # for tracking stack trace, add InnerClasses, Exception, Signature at keepattributes and define proguard when debug mode it is not working.

0b311903bbf311e78e1dbeaaf5edcd9d50010804‥add .Ds_Store line the reason is if we don't anyone confirm your directory without permissions.

## 追加情報
・デバッグでは、難読化を有効にしない設定の追加を行いました

・Gson, Retrofit の情報を得るために、 InnerClasses, Exception, Signatureを、keepattributesに追加しました。

・-keepattributes LineNumberTable,SourceFile,-renamesourcefileattribute SourceFileを利用し、スタックトレースから対応する行番号を得るためにプロガードを設定しました。

・.Ds_Storeで、ディレクトリの情報がOSによっては閲覧できる可能性があるので、.gitignoreに追加しました